### PR TITLE
Adds a optional parameter to Queue#bind and Socket#connect for the host.

### DIFF
--- a/lib/sockets/queue.js
+++ b/lib/sockets/queue.js
@@ -128,24 +128,28 @@ Queue.prototype.addSocket = function(sock){
 };
 
 /**
- * Bind to `port` and invoke `fn()`.
+ * Bind to `port` at `host` and invoke `fn()`.
+ *
+ * Defaults `host` to INADDR_ANY.
  *
  * Emits:
  *
  *  - `connection` when a connection is accepted
  *  - `bind` when bound and listening
  *
- * TODO: host
- *
  * @param {Number} port
  * @param {Function} fn
  * @api public
  */
 
-Queue.prototype.bind = function(port, fn){
+Queue.prototype.bind = function(port, host, fn){
+  if ('function' == typeof host) fn = host, host = undefined;
+
   var self = this;
   this.type = 'server';
-  debug('bind %s', port);
+  host = host || '0.0.0.0';
+
+  debug('bind %s:%s', host, port);
 
   this.server = net.createServer(function(sock){
     debug('connect %s', sock.remoteAddress);
@@ -161,5 +165,5 @@ Queue.prototype.bind = function(port, fn){
     self.emit('bind');
   });
 
-  this.server.listen(port, fn);
+  this.server.listen(port, host, fn);
 };

--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -47,7 +47,7 @@ function Socket() {
       debug('attempting reconnect');
       self.emit('reconnect attempt');
       sock.destroy();
-      self.connect(self.port);
+      self.connect(self.port, self.host);
       self.retry = Math.min(self.retryMaxTimeout, self.retry * 1.5);
     }, self.retry);
   });
@@ -68,20 +68,23 @@ function Socket() {
 Socket.prototype.__proto__ = Emitter.prototype;
 
 /**
- * Connect to `port` and invoke `fn()`.
+ * Connect to `port` at `host` and invoke `fn()`.
  *
- * TODO: host
+ * Defaults `host` to localhost.
  *
  * @param {Number} port
+ * @param {String} host
  * @param {Function} fn
  * @api public
  */
 
-Socket.prototype.connect = function(port, fn){
-  debug('connect %s', port);
+Socket.prototype.connect = function(port, host, fn){
+  if ('function' == host) fn = host, host = undefined;
   this.type = 'client';
   this.port = port;
-  this.sock.connect(port, '127.0.0.1');
+  this.host = host || '127.0.0.1';
+  debug('connect %s:%s', this.host, this.port);
+  this.sock.connect(this.port, this.host);
   this.callback = fn;
   return this;
 };


### PR DESCRIPTION
Adds a optional parameter to `Queue#bind` and `Socket#connect` for the host.
- bind() defaults to 0.0.0.0
- connect() defaults to 127.0.0.1

Was not sure if you were planning on going down the ZMQ style route of `fn('host:port')`, but this sticks with the node style of `fn(port, 'host')`. Never understood why ZMQ did that.....
