### PR TITLE
configurable fix

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -38,6 +38,7 @@ function Socket() {
   this.server = null;
   this.socks = [];
   this.map = {};
+  this.settings = {};
   this.format('none');
   this.set('identity', '\u0000');
   this.set('retry timeout', 100);


### PR DESCRIPTION
Kind of a hack?

Initializes "settings" in the base `Socket` constructor so that each inherited socket will get it's own "settings" object upon calling `Socket.call(...)`.
