### PR TITLE
Add support for unix sockets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
 
 TESTS = $(wildcard test/test.*.js)
-PER_TICK=1000
+# NOTE: for some reason, anything larger than 1 causes unix sockets to take a huge performance hit.
+PER_TICK=1
 SIZE=1024
 
 bm:
 	node benchmark/pub --size $(SIZE) --per-tick $(PER_TICK) &
 	node benchmark/sub --size $(SIZE)
 
+ubm:
+	node benchmark/pub --unix --size $(SIZE) --per-tick $(PER_TICK) &
+	node benchmark/sub --unix --size $(SIZE)
+
 test:
 	@./test/run $(TESTS)
-	
-.PHONY: test bm
+
+.PHONY: test bm ubm

--- a/benchmark/pub.js
+++ b/benchmark/pub.js
@@ -6,10 +6,12 @@ program
   .option('-T, --type <name>', 'socket type [pub]', 'pub')
   .option('-t, --per-tick <n>', 'messages per tick [1000]', parseInt)
   .option('-s, --size <n>', 'message size in bytes [1024]', parseInt)
+  .option('-u, --unix', 'use unix socket')
   .parse(process.argv)
 
+if(program.unix) try { require('fs').unlinkSync('/tmp/axonbenchmark'); } catch(err) {}
 var sock = ss.socket(program.type);
-sock.bind(3000);
+sock.bind(program.unix ? 'unix:///tmp/axonbenchmark' : 3000);
 console.log('pub bound');
 
 var perTick = program.perTick || 1000;

--- a/benchmark/sub.js
+++ b/benchmark/sub.js
@@ -6,10 +6,11 @@ var ss = require('..')
 program
   .option('-T, --type <name>', 'socket type [sub]', 'sub')
   .option('-s, --size <n>', 'message size in bytes [1024]', parseInt)
+  .option('-u, --unix', 'use unix socket')
   .parse(process.argv)
 
 var sock = ss.socket(program.type);
-sock.connect(3000);
+sock.connect(program.unix ? 'unix:///tmp/axonbenchmark' : 3000);
 
 var n = 0;
 var ops = 200;

--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -237,8 +237,10 @@ Socket.prototype.connect = function(port, host, fn){
 
   if ('string' == typeof port) {
     port = url.parse(port);
-    host = port.hostname;
-    port = parseInt(port.port, 10);
+    if(port.protocol && port.protocol.indexOf('unix') != 0) {
+      host = port.hostname;
+      port = parseInt(port.port, 10);
+    }
   }
 
   var sock = new net.Socket;
@@ -248,7 +250,7 @@ Socket.prototype.connect = function(port, host, fn){
   host = host || '127.0.0.1';
 
   sock.on('error', function(err){
-    if ('ECONNREFUSED' != err.code) {
+    if ('ECONNREFUSED' != err.code && 'ENOENT' != err.code) {
       self.emit('error', err);
     }
   });
@@ -278,7 +280,11 @@ Socket.prototype.connect = function(port, host, fn){
   });
 
   debug('connect attempt %s:%s', host, port);
-  sock.connect(port, host);
+  if(port.protocol && port.protocol.indexOf('unix') == 0) {
+    sock.connect(port.pathname);
+  } else {
+    sock.connect(port, host);
+  }
   return this;
 };
 
@@ -326,8 +332,10 @@ Socket.prototype.bind = function(port, host, fn){
 
   if ('string' == typeof port) {
     port = url.parse(port);
-    host = port.hostname;
-    port = parseInt(port.port, 10);
+    if(port.protocol && port.protocol.indexOf('unix') != 0) {
+      host = port.hostname;
+      port = parseInt(port.port, 10);
+    }
   }
 
   this.type = 'server';
@@ -337,6 +345,10 @@ Socket.prototype.bind = function(port, host, fn){
 
   debug('bind %s:%s', host, port);
   this.server.on('listening', this.emit.bind('bind'));
-  this.server.listen(port, host, fn);
+  if(port.protocol && port.protocol.indexOf('unix') == 0) {
+    this.server.listen(port.pathname, fn);
+  } else {
+    this.server.listen(port, host, fn);
+  }
   return this;
 };

--- a/test/test.unixsockets.js
+++ b/test/test.unixsockets.js
@@ -1,0 +1,19 @@
+
+var axon = require('..')
+  , should = require('should')
+  , req = axon.socket('req')
+  , rep = axon.socket('rep')
+
+req.bind('unix:///tmp/axontest', function(){
+  rep.connect('unix:///tmp/axontest');
+});
+
+rep.on('message', function(msg, reply){
+  reply('got "' + msg + '"');
+});
+
+req.send('hello', function(msg){
+  msg.toString().should.equal('got "hello"');
+  req.close();
+  rep.close();
+});


### PR DESCRIPTION
Adds support for unix sockets via unix://[path] URL to bind/connect functions.  Also modifies the benchmark with a flag that can utilize unix sockets.  Note that, on my macbook pro anyway, I saw disappointing performance vs. regular sockets.  I'll leave it up to you if you find any value in including this anyway.
