### PR TITLE
debugging socket removals

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -179,8 +179,12 @@ Socket.prototype.address = function(){
 
 Socket.prototype.removeSocket = function(sock){
   var i = this.socks.indexOf(sock);
-  debug('remove socket %d', i);
-  this.socks.splice(i, 1);
+  if (!~~i) {
+    debug('remove socket %d', i);
+    this.socks.splice(i, 1);
+  } else {
+    debug('could not remove unknown socket');
+  }
 };
 
 /**

--- a/test/test.socket.error-remove-sock.js
+++ b/test/test.socket.error-remove-sock.js
@@ -5,16 +5,17 @@ var axon = require('..')
 var a = axon.socket('push')
   , b = axon.socket('push')
   , c = axon.socket('push')
-  , pull = axon.socket('pull')
+  , pull = axon.socket('pull');
 
 a.bind(3001);
 b.bind(3002);
 c.bind(3003);
+
 pull.connect(3001);
 pull.connect(3002);
 pull.connect(3003);
 
-pull.on('error', function(err){
+pull.once('error', function(err){
   assert('boom' == err.message);
   assert(2 == pull.socks.length);
   var err = new Error('faux EPIPE');
@@ -22,23 +23,30 @@ pull.on('error', function(err){
   pull.socks[0]._destroy(err);
 });
 
-pull.on('ignored error', function(err){
+pull.once('ignored error', function(err){
   assert('EPIPE' == err.code);
   assert(1 == pull.socks.length);
+  a.close();
+  b.close();
   c.close();
   pull.close();
 });
 
+// 1 peer connect each
 a.on('connect', connect);
 b.on('connect', connect);
 c.on('connect', connect);
 
-var pending = 3;
-function connect() {
+// 3 peer connects
+pull.on('connect', connect);
+
+var pending = 6;
+
+function connect(){
   --pending || done();
 }
 
-function done() {
+function done(){
   assert(1 == a.socks.length);
   assert(1 == b.socks.length);
   assert(1 == c.socks.length);


### PR DESCRIPTION
See #54.

The -1 was because of ECONNREFUSED running `handleErorors()` -> `removeSocket()`, which since a connection was never made, it did not exist in the socks array. I am just ignoring and logging, seems cleaner than checking for error codes within `handleErrors()`.

I had to re-arrange the test because it kept sporadically working and not working... Added once() to "ignore error" events so only the EPIPE went and not ECONNREFUSED. Had to do pending=6 for done() because sometimes `pull == 3` failed, switching it around caused `a|b|c == 1` to fail. Of course, it would always pass if i used DEBUG? lol

Seems consistent now though...
