### PR TITLE
Added callback to Socket.close to mimic Socket.listen.

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -149,14 +149,14 @@ Socket.prototype.closeSockets = function(){
  * @api public
  */
 
-Socket.prototype.close = function(){
+Socket.prototype.close = function(fn){
   debug('closing');
   this.closing = true;
   this.closeSockets();
   if (this.server) {
     debug('closing server');
     this.server.on('close', this.emit.bind(this, 'close'));
-    this.server.close();
+    this.server.close(fn);
   }
 };
 

--- a/test/test.socket.close.js
+++ b/test/test.socket.close.js
@@ -1,0 +1,20 @@
+
+var axon = require('..')
+  , assert = require('better-assert');
+
+var pull = axon.socket('pull');
+
+var closed = false;
+var callbackClose = function() {
+  closed = true;
+}
+
+pull.bind(4444, function() {
+  pull.close(callbackClose);
+});
+
+pull.on('close', function() {
+  setTimeout(function() {
+    assert(closed === true);
+  }, 100);
+});


### PR DESCRIPTION
This callback is passed in to the server.close method to be called when the server closes down successfully. Mimics the functionality in Socket.listen -> server.listen.
