### PR TITLE
Small fixes to avoid some exceptions

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -79,6 +79,7 @@ Message.prototype.toBuffer = function(){
  */
 
 Message.prototype.pack = function(msg, meta){
+	if (!msg) msg = ''; /* in case of null don't break */
   if ('string' == typeof msg) msg = new Buffer(msg);
   var buf = new Buffer(msg.length + 4);
 

--- a/lib/sockets/req.js
+++ b/lib/sockets/req.js
@@ -92,7 +92,7 @@ ReqSocket.prototype.send = function(msg){
     }
   }
 
-  if (sock) {
+  if (sock && sock.writable) {
     sock.write(this.pack(args));
   } else {
     debug('no connected peers');


### PR DESCRIPTION
I encountered this exceptions multiple time with axon running on node 0.8.18
Error: This socket is closed.
at Socket._write (net.js:519:19)
at Socket.write (net.js:511:15)
at ReqSocket.send (proj/axon/lib/sockets/req.js:96:10)
....
And 
TypeError: Cannot read property 'length' of null
    at Message.pack (/proj/axon/lib/message.js:83:27)
    at Message.write (/proj/axon/lib/message.js:40:18)
....
Hope this helps without breaking anything else in the project design.
