### PR TITLE
ignore closed sockets on reply()

### DIFF
--- a/lib/sockets/rep.js
+++ b/lib/sockets/rep.js
@@ -50,7 +50,14 @@ RepSocket.prototype.onmessage = function(sock){
       var args = [].slice.call(arguments);
       args[0] = args[0] || null;
       args.push(id);
-      sock.write(self.pack(args));
+      
+      if (sock.writable) {
+        sock.write(self.pack(args));
+        return true;
+      } else {
+        debug('peer went away');
+        return false;
+      }
     }
   };
 };

--- a/test/test.reqrep.error-reply.js
+++ b/test/test.reqrep.error-reply.js
@@ -1,0 +1,24 @@
+
+var axon = require('..')
+  , assert = require('better-assert');
+
+var req = axon.socket('req')
+  , rep = axon.socket('rep');
+
+rep.bind(4444);
+req.connect(4444);
+
+rep.on('message', function(msg, reply){
+  setTimeout(function(){
+    assert(reply('ok') === false);
+    rep.close();
+  }, 50);
+});
+
+
+req.on('connect', function(){
+  req.send('hi', function(){});
+  setTimeout(function(){
+    req.close();
+  }, 25);
+});


### PR DESCRIPTION
Ignore closed sockets on reply(). Returns true / false in case someone wants to know if it sent.

Fixes #82
