### PR TITLE
Closing code fence missing in the readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -283,6 +283,7 @@ axon.codec.define('json', {
   encode: JSON.stringify,
   decode: JSON.parse
 });
+```
 
 __Note:__ codecs must be defined on both the sending and receiving ends, otherwise
 axon cannot properly decode the messages. You may of course ignore this


### PR DESCRIPTION
I left out a closing code fence in the README.md when adding the section on using json codecs. This commit adds the fence back in
