### PR TITLE
Fix unixsockets

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -289,13 +289,13 @@ Socket.prototype.connect = function(port, host, fn){
   if ('string' == typeof port) {
     port = url.parse(port);
 
-    if (port.protocol == "unix:") {
+    if (port.port) {
+      host = port.hostname || '0.0.0.0';
+      port = parseInt(port.port, 10);
+    } else {
       host = fn;
       fn = undefined;
       port = port.pathname;
-    } else {
-      host = port.hostname || '0.0.0.0';
-      port = parseInt(port.port, 10);
     }
   } else {
     host = host || '0.0.0.0';
@@ -305,7 +305,6 @@ Socket.prototype.connect = function(port, host, fn){
   var sock = new net.Socket;
   sock.setNoDelay();
   this.type = 'client';
-  port = port;
 
   this.handleErrors(sock);
 
@@ -385,14 +384,12 @@ Socket.prototype.bind = function(port, host, fn){
   if ('string' == typeof port) {
     port = url.parse(port);
 
-    if ('unix:' == port.protocol) {
-      host = fn;
-      fn = undefined;
-      port = port.pathname;
-      unixSocket = true;
-    } else {
+    if (port.port) {
       host = port.hostname || '0.0.0.0';
       port = parseInt(port.port, 10);
+    } else {
+      port = port.pathname;
+      unixSocket = true;
     }
   } else {
     host = host || '0.0.0.0';
@@ -405,7 +402,9 @@ Socket.prototype.bind = function(port, host, fn){
   debug('bind %s:%s', host, port);
   this.server.on('listening', this.emit.bind(this, 'bind'));
 
-  if (unixSocket) {
+  if (!unixSocket) {
+    this.server.listen(port, host, fn)
+  } else {
     // TODO: move out
     this.server.on('error', function(e) {
       if (e.code == 'EADDRINUSE') {
@@ -417,14 +416,16 @@ Socket.prototype.bind = function(port, host, fn){
         var clientSocket = new net.Socket();
         
         clientSocket.on('error', function(e2) {
-          if (e2.code == 'ECONNREFUSED') {
-            // No other server listening, so we can delete stale
-            // socket file and reopen server socket
-            fs.unlink(port);
-            self.server.listen(port, host, fn);
+          if (e2.code !== 'ECONNREFUSED') {
+            return fn && fn(e);
           }
+          // No other server listening, so we can delete stale
+          // socket file and reopen server socket
+          fs.unlink(port, function(){
+            self.server.listen(port, fn);
+          });
         });
-
+    
         clientSocket.connect({path: port}, function() {
           // Connection is possible, so other server is listening
           // on this file socket
@@ -432,8 +433,8 @@ Socket.prototype.bind = function(port, host, fn){
         });
       }
     });
+    this.server.listen(port, fn)
   }
-
-  this.server.listen(port, host, fn);
+  
   return this;
 };

--- a/test/test.unixsocket.js
+++ b/test/test.unixsocket.js
@@ -5,7 +5,7 @@ var axon = require('..')
 var req = axon.socket('req')
   , rep = axon.socket('rep');
 
-var path = 'unix://' + process.cwd() + '/test.sock'
+var path = process.cwd() + '/test.sock'
 var bound = false;
 
 rep.connect(path);


### PR DESCRIPTION
- reconnect now works properly with unixsockets
- the callback function passed to `socket.listen()` will
  return the `EADDRINUSE` if the attempt to connect
  does _not_ result in `ECONNREFUSED`
- provide a callback to `fs.link()` when recycling the
  stale socket file (see [1](https://github.com/joyent/node/blob/v0.10.21-release/lib/fs.js#L84))
