### PR TITLE
change connect event to emit socket

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -286,7 +286,7 @@ Socket.prototype.connect = function(port, host, fn){
     self.connected = true;
     self.addSocket(sock);
     self.retry = self.get('retry timeout');
-    self.emit('connect');
+    self.emit('connect', sock);
     fn && fn();
   });
 


### PR DESCRIPTION
I have a need for some information from the socket after a successful connect.

Tests pass. Doesn't seem to break anything by providing a reference to `sock`.
