### PR TITLE
Add typechecking to Socket#pack to avoid parsing undefined

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -82,12 +82,24 @@ Socket.prototype.use = function(plugin){
 /**
  * Creates a new `Message` and write the `args`.
  *
+ * Will throw if any of the provided `args` are `undefined`, given that
+ * JSON.stringify's result will be coerced to `'undefined'`, which JSON.parse
+ * cannot handle.
+ *
  * @param {Array} args
  * @return {Buffer}
  * @api private
  */
 
 Socket.prototype.pack = function(args){
+  var len = args.length;
+
+  for (var i = 0; i < len; i++) {
+    if (args[i] === undefined) {
+      throw new Error('cannot pack undefined');
+    }
+  }
+
   var msg = new Message(args);
   return msg.toBuffer();
 };

--- a/test/test.arg-types.js
+++ b/test/test.arg-types.js
@@ -14,8 +14,19 @@ var done;
 push.bind(4000);
 push.send('foo', { bar: 'baz' }, ['some', 1], new Buffer('hello'));
 
+assert.throws(function() {
+  push.send(undefined);
+}, /undefined/, 'send should reject unserializable types');
+assert.throws(function() {
+  push.send(null, undefined);
+}, /undefined/, 'send should reject unserializable types');
+assert.throws(function() {
+  push.send({ bar: 'baz' }, undefined);
+}, /undefined/, 'send should reject unserializable types');
+
 pull.connect(4000);
 pull.on('message', function(a, b, c, d){
+  assert(!done, 'message already received');
   assert('string' == typeof a);
   b.should.eql({ bar: 'baz' });
   c.should.eql(['some', 1]);


### PR DESCRIPTION
Fixes #124 provided we can make the tests work.

> Alright, so I can make the tests fail by adding `push.send(undefined);` to line 16 of `test.arg-types.js`, simply because it causes the `Unexpected token u` SyntaxError.
> 
> The message is then encoded as a buffer containing `110000000b6a3a756e646566696e6564`, which includes `j:undefined`. That means that, as confirmed by walking through with Node's debugger, the `JSON.stringify` [line](https://github.com/visionmedia/node-amp-message/blob/10cdca4158dc21ae80730758ab62dd4ac0904ee1/index.js#L123) in node-amp-message is being passed `undefined`, which returns `undefined`, which is coerced into the string `'undefined'`. I'm wondering whether this would be more suited for amp-message rather than axon, given that we're not currently looping through the args before buffering them in `Socket#pack`.
> 
> Also, given that `send` usually queues messages until the socket is actually ready, the error won't be thrown until the socket is ready which means I can't use `assert.throws` in the test case.
