### PR TITLE
Allow port numbers passed to .bind() and .connect() to be strings

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -244,6 +244,8 @@ Socket.prototype.connect = function(port, host, fn){
   if ('server' == this.type) throw new Error('cannot connect() after bind()');
   if ('function' == typeof host) fn = host, host = undefined;
 
+  if(parseInt(port, 10) == port) port = parseInt(port, 10);
+
   if ('string' == typeof port) {
     port = url.parse(port);
 
@@ -263,7 +265,6 @@ Socket.prototype.connect = function(port, host, fn){
   var sock = new net.Socket;
   sock.setNoDelay();
   this.type = 'client';
-  port = port;
 
   this.handleErrors(sock);
 
@@ -339,6 +340,8 @@ Socket.prototype.bind = function(port, host, fn){
   if ('function' == typeof host) fn = host, host = undefined;
 
   var unixSocket = false;
+
+  if(parseInt(port, 10) == port) port = parseInt(port, 10);
 
   if ('string' == typeof port) {
     port = url.parse(port);

--- a/test/test.socket.portstring.js
+++ b/test/test.socket.portstring.js
@@ -1,0 +1,19 @@
+var axon = require('..')
+  , should = require('should');
+
+var req = axon.socket('req')
+  , rep = axon.socket('rep');
+
+// ports as strings
+req.bind('4000');
+rep.connect('4000');
+
+rep.on('message', function(msg, reply){
+  reply('got "' + msg + '"');
+});
+
+req.send('hello', function(msg){
+  msg.toString().should.equal('got "hello"');
+  req.close();
+  rep.close();
+});


### PR DESCRIPTION
My team is doing some IPC stuff where we spawn child processes with arguments telling them what port to connect on. If the port number given to .bind() or .connect() is a string like "3000", you get ECONNREFUSED when url.parse() tries to run over "3000".

Simple patch attached to see if the port is a number before trying to parse out a hostname and port from it. Test case added as well.

Thanks for the work you do!
