### PR TITLE
Floating-point durations to setTimeout may cause infinite loop

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -277,7 +277,7 @@ Socket.prototype.connect = function(port, host, fn){
       self.emit('reconnect attempt');
       sock.destroy();
       self.connect(port, host);
-      self.retry = Math.min(max, retry * 1.5);
+      self.retry = Math.round(Math.min(max, retry * 1.5));
     }, retry);
   });
 


### PR DESCRIPTION
This issue may be related to node, please checkout [this page](https://github.com/joyent/node/issues/5796).
The problem appeared when I use `axon` on my server (axon version: 0.2.0, node version: 0.10.30). this patch work for us.
