### PR TITLE
SubEmitterSocket should apply listener with `self` rather than `this`

### DIFF
--- a/lib/sockets/sub-emitter.js
+++ b/lib/sockets/sub-emitter.js
@@ -35,7 +35,7 @@ function SubEmitterSocket() {
  * @api private
  */
 
-SubEmitterSocket.prototype.onmessage = function(sock){
+SubEmitterSocket.prototype.onmessage = function(){
   var listeners = this.listeners;
   var self = this;
 

--- a/lib/sockets/sub-emitter.js
+++ b/lib/sockets/sub-emitter.js
@@ -35,7 +35,7 @@ function SubEmitterSocket() {
  * @api private
  */
 
-SubEmitterSocket.prototype.onmessage = function(){
+SubEmitterSocket.prototype.onmessage = function(sock){
   var listeners = this.listeners;
   var self = this;
 
@@ -49,7 +49,7 @@ SubEmitterSocket.prototype.onmessage = function(){
       var m = listener.re.exec(topic);
       if (!m) continue;
 
-      listener.fn.apply(this, m.slice(1).concat(msg.args));
+      listener.fn.apply(self, m.slice(1).concat(msg.args));
     }
   }
 };

--- a/test/test.emitter.arg-types.js
+++ b/test/test.emitter.arg-types.js
@@ -1,0 +1,34 @@
+
+var axon = require('..');
+var should = require('should');
+var assert = require('assert');
+
+var pub = axon.socket('pub-emitter');
+var sub = axon.socket('sub-emitter');
+
+// arg type checks
+
+var done = false;
+
+pub.bind(4000);
+
+setTimeout(function() {
+  pub.emit('foo', { bar: 'baz' }, ['some', 1], new Buffer('hello'));
+}, 50);
+
+sub.connect(4000);
+sub.on('foo', function(a, b, c){
+  assert(this instanceof axon.SubEmitterSocket);
+  a.should.eql({ bar: 'baz' });
+  b.should.eql(['some', 1]);
+  assert(Buffer.isBuffer(c));
+  assert('hello' == c.toString());
+
+  sub.close();
+  pub.close();
+  done = true;
+});
+
+process.on('exit', function(){
+  assert(done);
+});

--- a/test/test.pubsub.arg-types.js
+++ b/test/test.pubsub.arg-types.js
@@ -1,0 +1,35 @@
+
+var axon = require('..');
+var should = require('should');
+var assert = require('assert');
+
+var pub = axon.socket('pub');
+var sub = axon.socket('sub');
+
+// arg type checks
+
+var done = false;
+
+pub.bind(4000);
+
+setTimeout(function() {
+  pub.send('foo', { bar: 'baz' }, ['some', 1], new Buffer('hello'));
+}, 50);
+
+sub.connect(4000);
+sub.on('message', function(a, b, c, d){
+  assert(this instanceof axon.SubSocket);
+  assert('string' == typeof a);
+  b.should.eql({ bar: 'baz' });
+  c.should.eql(['some', 1]);
+  assert(Buffer.isBuffer(d));
+  assert('hello' == d.toString());
+
+  sub.close();
+  pub.close();
+  done = true;
+});
+
+process.on('exit', function(){
+  assert(done);
+});


### PR DESCRIPTION
Receiving a message via a `SubSocket` allows the user to access the underlying socket, whereas in `SubEmitterSocket` only the message buffer is exposed. I came across this inconsistency when I needed to access a publishing socket's identity from within a listener.

Please compare the suggested solution with the current implementation of `SubSocket.prototype.onmessage`.