### PR TITLE
Added node 4 as an acceptable engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "rpc"
   ],
   "engines": {
-    "node": "0.10.x || 0.11.x"
+    "node": "0.10.x || 0.11.x || 0.12.x || 4.x.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The tests are already passing for node 4, but npm complains about the missing engine.
