### PR TITLE
 Make 0 for "retry timeout" disable auto-reconnection

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -272,6 +272,7 @@ Socket.prototype.connect = function(port, host, fn){
     self.removeSocket(sock);
     if (self.closing) return self.emit('close');
     var retry = self.retry || self.get('retry timeout');
+    if (retry === 0) return;
     setTimeout(function(){
       debug('%s attempting reconnect', self.type);
       self.emit('reconnect attempt');


### PR DESCRIPTION
Sometimes auto-reconnection is not desirable, so we need a way to disable it.