### PR TITLE
bound cursor within safe integer range

### DIFF
--- a/lib/plugins/round-robin.js
+++ b/lib/plugins/round-robin.js
@@ -41,6 +41,9 @@ module.exports = function(options){
       var socks = this.socks;
       var len = socks.length;
       var sock = socks[n++ % len];
+      if (n > Number.MAX_SAFE_INTEGER) {
+        n = 0;
+      }
 
       var msg = slice(arguments);
 


### PR DESCRIPTION
if round-robin cursor achieves 9007199254740992 (2^53), n++ will not change anymore.