### PR TITLE
If closing, don't try to reconnect

### DIFF
--- a/lib/sockets/sock.js
+++ b/lib/sockets/sock.js
@@ -275,6 +275,7 @@ Socket.prototype.connect = function(port, host, fn){
     var retry = self.retry || self.get('retry timeout');
     setTimeout(function(){
       debug('%s attempting reconnect', self.type);
+      if (self.closing) return;
       self.emit('reconnect attempt');
       sock.destroy();
       self.connect(port, host);


### PR DESCRIPTION
If we are in the process of closing, do not attempt a reconnect in setTimeout()